### PR TITLE
🐛 Remove the request-header from the mobile api server deployment

### DIFF
--- a/hack/install-apiserver/openshift/deployment.json
+++ b/hack/install-apiserver/openshift/deployment.json
@@ -144,7 +144,6 @@
                                     "--authentication-skip-lookup",
                                     "--tls-cert-file=/mnt/apiserver-config/serving.crt",
                                     "--tls-private-key-file=/mnt/apiserver-config/serving.key",
-                                    "--requestheader-client-ca-file=/mnt/apiserver-cert/front-proxy-ca.crt",
                                     "--v=10"
                                 ],
                                 "volumeMounts": [{


### PR DESCRIPTION
This change prevents a 401 when using the OpenShift Web console.
This is intended as a temporary fix for this problem, and is not for
production use